### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,8 @@ Pearson {
   email: 'jadosn44.santos@gmail.com',
   phone: '(48) 99932-8092',
   location: {
-    street: 'Almirante Carlos da Silveira Carneiro',
-    number: 394,
-    zipcode: 88025350
+    state: 'Santa Cantarina',
+    city: 'Florianopolis',
   },
   platforms: [
     { name: 'Github', url: 'http://github.com/jadson179' },


### PR DESCRIPTION
Recomendo remover sua rua, cep e até número da sua casa, por motivos de segurança, mesmo em tempos de Pandemia. Quem for contratar seus serviços/pessoa, gostará de saber somente sua localização como cidade e estado.

E se você está disposto ir até o lugar onde eles ficam, isso se não for Remoto.